### PR TITLE
set explosion positions __after__ adding child to tree

### DIFF
--- a/Unit/BaseUnit/unit.gd
+++ b/Unit/BaseUnit/unit.gd
@@ -239,10 +239,10 @@ func sort_enemies_in_attack_area_by_distance(list):
 @rpc("any_peer", "call_local")
 func spawn_explosion_scene(spawn_pos: Vector2):
 	var explosion = explosion_scene.instantiate()
-	explosion.global_position = spawn_pos
 	@warning_ignore("integer_division")
 	explosion.scale *= (width / 32)
 	add_sibling(explosion, true)
+	explosion.global_position = spawn_pos
 
 
 func _on_multiplayer_synchronizer_tree_entered():


### PR DESCRIPTION
This resolves the issue of explosions spawning at (0, 0) on the client-side